### PR TITLE
array support

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLColumn.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLColumn.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A PostgreSQL column type and size.
 public struct PostgreSQLColumn {
     /// The columns data type.
@@ -23,67 +21,3 @@ public protocol PostgreSQLColumnStaticRepresentable {
     static var postgreSQLColumn: PostgreSQLColumn { get }
 }
 
-/// MARK: Default Implementations
-
-extension Data: PostgreSQLColumnStaticRepresentable {
-    /// See `PostgreSQLColumnStaticRepresentable.postgreSQLColumn`
-    public static var postgreSQLColumn: PostgreSQLColumn { return .init(type: .bytea) }
-}
-
-extension UUID: PostgreSQLColumnStaticRepresentable {
-    /// See `PostgreSQLColumnStaticRepresentable.postgreSQLColumn`
-    public static var postgreSQLColumn: PostgreSQLColumn { return .init(type: .uuid) }
-}
-
-extension Date: PostgreSQLColumnStaticRepresentable {
-    /// See `PostgreSQLColumnStaticRepresentable.postgreSQLColumn`
-    public static var postgreSQLColumn: PostgreSQLColumn { return .init(type: .timestamp) }
-}
-
-extension FixedWidthInteger {
-    /// See `PostgreSQLColumnStaticRepresentable.postgreSQLColumn`
-    public static var postgreSQLColumn: PostgreSQLColumn {
-        switch bitWidth {
-        case 64: return .init(type: .int8)
-        case 32: return .init(type: .int4)
-        case 16: return .init(type: .int2)
-        case 8: return .init(type: .char)
-        default: fatalError("Unexpected \(Self.self) bit width: \(bitWidth)")
-        }
-    }
-}
-
-extension Int: PostgreSQLColumnStaticRepresentable { }
-extension Int8: PostgreSQLColumnStaticRepresentable { }
-extension Int16: PostgreSQLColumnStaticRepresentable { }
-extension Int32: PostgreSQLColumnStaticRepresentable { }
-extension Int64: PostgreSQLColumnStaticRepresentable { }
-extension UInt: PostgreSQLColumnStaticRepresentable { }
-extension UInt8: PostgreSQLColumnStaticRepresentable { }
-extension UInt16: PostgreSQLColumnStaticRepresentable { }
-extension UInt32: PostgreSQLColumnStaticRepresentable { }
-extension UInt64: PostgreSQLColumnStaticRepresentable { }
-
-extension BinaryFloatingPoint {
-    /// See `PostgreSQLColumnStaticRepresentable.postgreSQLColumn`
-    public static var postgreSQLColumn: PostgreSQLColumn {
-        switch exponentBitCount + significandBitCount + 1 {
-        case 64: return .init(type: .float8)
-        case 32: return .init(type: .float4)
-        default: fatalError("Unexpected \(Self.self) bit width: \(exponentBitCount + significandBitCount + 1)")
-        }
-    }
-}
-
-extension Float: PostgreSQLColumnStaticRepresentable { }
-extension Double: PostgreSQLColumnStaticRepresentable { }
-
-extension String: PostgreSQLColumnStaticRepresentable {
-    /// See `PostgreSQLColumnStaticRepresentable.postgreSQLColumn`
-    public static var postgreSQLColumn: PostgreSQLColumn { return .init(type: .text) }
-}
-
-extension Bool: PostgreSQLColumnStaticRepresentable {
-    /// See `PostgreSQLColumnStaticRepresentable.postgreSQLColumn`
-    public static var postgreSQLColumn: PostgreSQLColumn { return .init(type: .bool) }
-}

--- a/Sources/FluentPostgreSQL/PostgreSQLDatabase+SchemaSupporting.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLDatabase+SchemaSupporting.swift
@@ -6,30 +6,10 @@ extension PostgreSQLDatabase: SchemaSupporting {
     /// See `SchemaSupporting.dataType`
     public static func dataType(for field: SchemaField<PostgreSQLDatabase>) -> String {
         var string: String
-        switch field.type.type {
-        case .bool: string = "BOOLEAN"
-        case .bytea: string = "BYTEA"
-        case .char: string = "CHAR"
-        case .int8: string = "BIGINT"
-        case .int2: string = "SMALLINT"
-        case .int4, .oid, .regproc: string = "INTEGER"
-        case .text, .name: string = "TEXT"
-        case .point: string = "POINT"
-        case .float4: string = "REAL"
-        case .float8: string = "DOUBLE PRECISION"
-        case ._aclitem: string = "_aclitem"
-        case .bpchar: string = "BPCHAR"
-        case .varchar: string = "VARCHAR"
-        case .date: string = "DATE"
-        case .time: string = "TIME"
-        case .timestamp: string = "TIMESTAMP"
-        case .numeric: string = "NUMERIC"
-        case .void: string = "VOID"
-        case .uuid: string = "UUID"
-        case .jsonb: string = "JSONB"
-        case .json: string = "JSON"
-        case .pg_node_tree: string = "pg_node_tree"
-        default: string = "VOID" // FIXME: better error?
+        if let knownSQLName = field.type.type.knownSQLName {
+            string = knownSQLName
+        } else {
+            string = "VOID"
         }
 
         if field.type.size >= 0 {

--- a/Sources/FluentPostgreSQL/PostgreSQLType.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLType.swift
@@ -1,10 +1,37 @@
+import Foundation
+
 /// A type that is compatible with PostgreSQL schema and data.
 public protocol PostgreSQLType: PostgreSQLColumnStaticRepresentable, PostgreSQLDataCustomConvertible { }
+
+extension PostgreSQLColumnStaticRepresentable where Self: PostgreSQLDataCustomConvertible {
+    /// The `PostgreSQLColumn` type that best represents this type.
+    public static var postgreSQLColumn: PostgreSQLColumn { return .init(type: Self.postgreSQLDataType) }
+}
 
 /// A type that is supports being represented as JSONB in a PostgreSQL database.
 public protocol PostgreSQLJSONType: PostgreSQLType, PostgreSQLJSONCustomConvertible { }
 
-extension PostgreSQLJSONType {
-    /// The `PostgreSQLColumn` type that best represents this type.
-    public static var postgreSQLColumn: PostgreSQLColumn { return .init(type: .jsonb) }
-}
+/// A type that is supports being represented as T[] in a PostgreSQL database.
+public protocol PostgreSQLArrayType: PostgreSQLType, PostgreSQLArrayCustomConvertible { }
+
+/// MARK: Default Implementations
+
+extension Data: PostgreSQLType { }
+extension UUID: PostgreSQLType { }
+extension Date: PostgreSQLType { }
+extension Int: PostgreSQLType { }
+extension Int8: PostgreSQLType { }
+extension Int16: PostgreSQLType { }
+extension Int32: PostgreSQLType { }
+extension Int64: PostgreSQLType { }
+extension UInt: PostgreSQLType { }
+extension UInt8: PostgreSQLType { }
+extension UInt16: PostgreSQLType { }
+extension UInt32: PostgreSQLType { }
+extension UInt64: PostgreSQLType { }
+extension Float: PostgreSQLType { }
+extension Double: PostgreSQLType { }
+extension String: PostgreSQLType { }
+extension Bool: PostgreSQLType { }
+extension Array: PostgreSQLArrayType { }
+extension Dictionary: PostgreSQLJSONType { }


### PR DESCRIPTION
Adds array support conveniences to Fluent PostgreSQL.

- Swift `Array` automatically becomes `T[]` column
- Swift `Dictionary` automatically becomes `JSONB` column
- Custom types (such as `Pet` below) can be conformed to `PostgreSQLType`
    - `PostgreSQLJSONType` for easy `JSONB` conformance (where Self is `Codable`)
    - `PostgreSQLArrayType` for easy `T[]` conformance (where Element is a `PostgreSQLType`)

```swift
struct Pet: PostgreSQLJSONType {
    var name: String
}

final class User: PostgreSQLModel, Migration {
    static let idKey = \User.id
    var id: Int?
    var name: String
    var age: Int?
    var favoriteColors: [String]
    var pet: Pet
    var dict: [String: String]

    init(id: Int? = nil, name: String, pet: Pet) {
        self.favoriteColors = []
        self.dict = [:]
        self.id = id
        self.name = name
        self.pet = pet
    }
}
```

Results in:

```sql
CREATE TABLE "users" (
    "id" BIGINT GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY, 
    "name" TEXT NOT NULL, 
    "age" BIGINT, 
    "favoriteColors" TEXT[] NOT NULL, 
    "pet" JSONB NOT NULL, 
    "dict" JSONB NOT NULL
)
```