### PR TITLE
Fix dependency versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,16 +9,16 @@ let package = Package(
     ],
     dependencies: [
         // Swift Promises, Futures, and Streams.
-        .package(url: "https://github.com/vapor/async.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/async.git", .exact("1.0.0-beta.1")),
 
         // Core extensions, type-aliases, and functions that facilitate common tasks.
-        .package(url: "https://github.com/vapor/core.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/core.git", .exact("3.0.0-beta.1")),
 
         // Swift ORM framework (queries, models, and relations) for building NoSQL and SQL database integrations.
-        .package(url: "https://github.com/vapor/fluent.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/fluent.git", .exact("3.0.0-beta.1")),
 
         // Pure Swift, async/non-blocking client for PostgreSQL.
-        .package(url: "https://github.com/vapor/postgresql.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/postgresql.git", .exact("1.0.0-beta.1")),
     ],
     targets: [
         .target(name: "FluentPostgreSQL", dependencies: ["Async", "CodableKit", "Fluent", "FluentSQL", "PostgreSQL"]),


### PR DESCRIPTION
Use beta tags instead of branches to enable swift package manager to correctly resolve dependencies.