### PR TITLE
add default value

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLColumn.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLColumn.swift
@@ -6,10 +6,14 @@ public struct PostgreSQLColumn {
     /// The columns size. Negative values mean varying size.
     public let size: Int16
 
+    /// This column's default value.
+    public var `default`: String?
+
     /// Creates a new `PostgreSQLColumn`.
-    public init(type: PostgreSQLDataType, size: Int16? = nil) {
+    public init(type: PostgreSQLDataType, size: Int16? = nil, default: String? = nil) {
         self.type = type
         self.size = size ?? -1
+        self.default = `default`
     }
 }
 

--- a/Sources/FluentPostgreSQL/PostgreSQLDatabase+SchemaSupporting.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLDatabase+SchemaSupporting.swift
@@ -31,6 +31,10 @@ extension PostgreSQLDatabase: SchemaSupporting, IndexSupporting {
             string += " NOT NULL"
         }
 
+        if let d = field.type.default {
+            string += " DEFAULT \(d)"
+        }
+
         return string
     }
 


### PR DESCRIPTION
- [x] adds `DEFAULT ...` support to PostgreSQL column

This doesn't have a great use case yet, as it's impossible to set a model's property to `nil` and _not_ have that `nil` forwarded to the DB (which overrides the default). But this can be further looked into in Fluent itself. Take a look at the tests added here to see a workaround.