### PR TITLE
Make class PostgreSQLSQLSerializer public

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLSQLSerializer.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLSQLSerializer.swift
@@ -1,6 +1,6 @@
 import FluentSQL
 
-internal class PostgreSQLSQLSerializer: SQLSerializer {
+public final class PostgreSQLSQLSerializer: SQLSerializer {
     /// The current placeholder offset used to create PostgreSQL
     /// placeholders for parameterized queries.
     var placeholderOffset: Int

--- a/Sources/FluentPostgreSQL/PostgreSQLSQLSerializer.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLSQLSerializer.swift
@@ -3,20 +3,20 @@ import FluentSQL
 public final class PostgreSQLSQLSerializer: SQLSerializer {
     /// The current placeholder offset used to create PostgreSQL
     /// placeholders for parameterized queries.
-    var placeholderOffset: Int
+    private var placeholderOffset: Int
 
     /// Creates a new `PostgreSQLSQLSerializer`
-    init() {
+    public init() {
         self.placeholderOffset = 1
     }
 
     /// See `SQLSerializer.makeEscapedString(from:)`
-    func makeEscapedString(from string: String) -> String {
+    public func makeEscapedString(from string: String) -> String {
         return "\"\(string)\""
     }
 
     /// See `SQLSerializer.makePlaceholder(name:)`
-    func makePlaceholder(name: String) -> String {
+    public func makePlaceholder(name: String) -> String {
         defer { placeholderOffset += 1 }
         return "$\(placeholderOffset)"
     }


### PR DESCRIPTION
Hi

Sometimes we will query raw SQL like this, so should make class PostgreSQLSQLSerializer public.

```swift
let columns = [
    "bid",
    "time",
]

let sqlSerializer = PostgreSQLSQLSerializer()
var statement: [String] = []
var parameters: [PostgreSQLData] = []

let table = "table"
statement.append("INSERT INTO")
statement.append(sqlSerializer.makeEscapedString(from: table))

statement.append("(" + columns.map { sqlSerializer.makeEscapedString(from: $0) }.joined(separator: ", ") + ")")
statement.append("VALUES")

let now = Date()
statement.append("(" + columns.map { sqlSerializer.makePlaceholder(name: $0) }.joined(separator: ", ") + ")")

statement.append("ON CONFLICT (" + sqlSerializer.makeEscapedString(from: "bid") + ") DO NOTHING")

parameters += [
    try "bid".convertToPostgreSQLData(),
    try Date().convertToPostgreSQLData(),
]

let sqlString = statement.joined(separator: " ")
try conn.query(sqlString, parameters)
``` 