### PR TITLE
Replace a few string interpolations with string concatenations

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLSQLSerializer.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLSQLSerializer.swift
@@ -12,12 +12,12 @@ internal class PostgreSQLSQLSerializer: SQLSerializer {
 
     /// See `SQLSerializer`
     func makeEscapedString(from string: String) -> String {
-        return "\"\(string)\""
+        return "\"" + string + "\""
     }
 
     /// See `SQLSerializer`
     func makePlaceholder() -> String {
         defer { placeholderOffset += 1 }
-        return "$\(placeholderOffset)"
+        return "$" + String(describing: placeholderOffset)
     }
 }


### PR DESCRIPTION
String concatenations are said to be [quite a bit faster](https://mjtsai.com/blog/2018/03/09/faster-swift-string-concatenation/), and especially `makePlaceholder` might get visited fairly often.