### PR TITLE
Allow to create model with pre-given UUID idKey

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLDatabase+QuerySupporting.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLDatabase+QuerySupporting.swift
@@ -105,7 +105,7 @@ extension PostgreSQLDatabase: QuerySupporting {
     {
         switch event {
         case .willCreate:
-            if M.ID.self == UUID.self {
+            if M.ID.self == UUID.self, model.fluentID == nil {
                 var model = model
                 model.fluentID = UUID() as? M.ID
                 return conn.future(model)


### PR DESCRIPTION
### The problem
When I'm trying to save model to the database with specified UUID ID it saves with another random UUID ID.

### Why I need this fix
I'm trying to transfer data from another database and I really need to use my old UUIDs as PRIMARY KEY ID.

### Workaround
We should check if UUID ID is already specified and only in case when it isn't fluent should generate random UUID.