### PR TITLE
Change default postgreSQLEnumTypeName to include full type path

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLEnum.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLEnum.swift
@@ -5,7 +5,14 @@ public protocol PostgreSQLEnum: PostgreSQLExpressionRepresentable, CaseIterable,
 extension PostgreSQLEnum {
     /// See `PostgreSQLEnum`.
     public static var postgreSQLEnumTypeName: String {
-        return String(reflecting: self).replacingOccurrences(of: ".", with: "_").uppercased()
+        return String(reflecting: self)
+            .components(separatedBy: ".")
+            .dropFirst()
+            .joined(separator: "_")
+            // TODO: Determine if this should actually be uppercased.
+            // The PostgreSQL documentation for the ENUM type always
+            // shows this name being lowercased.
+            .uppercased()
     }
     
     /// See `PostgreSQLDataTypeStaticRepresentable`.

--- a/Sources/FluentPostgreSQL/PostgreSQLEnum.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLEnum.swift
@@ -5,7 +5,7 @@ public protocol PostgreSQLEnum: PostgreSQLExpressionRepresentable, CaseIterable,
 extension PostgreSQLEnum {
     /// See `PostgreSQLEnum`.
     public static var postgreSQLEnumTypeName: String {
-        return "\(self)".uppercased()
+        return String(reflecting: self).replacingOccurrences(of: ".", with: "_").uppercased()
     }
     
     /// See `PostgreSQLDataTypeStaticRepresentable`.


### PR DESCRIPTION
This PR changes the default `postgreSQLEnumTypeName` by adding the entire type's path to the name.

#### Example:
Consider the following case:
```swift
class Foo {
    var kind: Kind

    enum Kind: PostgreSQLEnum {
        ...
    }
}

class Bar {
    var kind: Kind

    enum Kind: PostgreSQLEnum {
        ...
    }
}
```

The two classes, `Foo` and `Bar`, each have a nested enum called `Kind`, each a `PostgreSQLEnum`.

Currently the default `postgreSQLEnumTypeName` for both of these nested enums is the same: `"KIND"`. Meaning that the resulting Postgres ENUM type for the first would be overridden by the second with no indication to the user that this happened.

This PR would resolve that nuance by changing the default `postgreSQLEnumTypeName` to return unique names: `"FOO_KIND"` and `"BAR_KIND"`.

#### Motivation:

This change is related to an issue discussed [here](https://github.com/vapor/fluent-postgresql/issues/82). The motivating factor being, that in Swift, the types `Foo.Kind` and `Bar.Kind` are unique and distinguishable by the type system. It should then be reasonable to expect the default `postgreSQLEnumTypeName`s to be unique and the resulting Postgres ENUM types to be unique and distinguishable whereas currently, the first ENUM type created will be overridden by the second. This is counter-intuitive behavior, because it should be expected that two unique Swift enums will result in two unique Postgres ENUMs. In order to fully resolve the [linked issue](https://github.com/vapor/fluent-postgresql/issues/82), and do so by default, this is a necessary change and will have a companion PR at `Fluent` to update the default `migrationName` (https://github.com/vapor/fluent/pull/544).

#### Impact:

This could potentially have an impact on existing codebases by changing `postgreSQLEnumTypeName`s that are already in place.