### PR TITLE
Bump Swift minimum to 6.0

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,22 +5,22 @@ concurrency:
 on:
   pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
   push: { branches: [ main ] }
-
+permissions:
+  contents: read
 env:
   LOG_LEVEL: info
-  SWIFT_DETERMINISTIC_HASHING: 1
-  POSTGRES_HOSTNAME: 'psql-a'
-  POSTGRES_HOSTNAME_A: 'psql-a'
-  POSTGRES_HOSTNAME_B: 'psql-b'
-  POSTGRES_DB: 'test_database_a'
-  POSTGRES_DB_A: 'test_database_a'
-  POSTGRES_DB_B: 'test_database_b'
-  POSTGRES_USER: 'test_username'
-  POSTGRES_USER_A: 'test_username'
-  POSTGRES_USER_B: 'test_username'
-  POSTGRES_PASSWORD: 'test_password'
-  POSTGRES_PASSWORD_A: 'test_password'
-  POSTGRES_PASSWORD_B: 'test_password'
+  POSTGRES_HOSTNAME_A: &postgres_host_a 'psql-a'
+  POSTGRES_HOSTNAME_B: &postgres_host_b 'psql-b'
+  POSTGRES_HOSTNAME: *postgres_host_a
+  POSTGRES_DB_A: &postgres_db_a 'test_database_a'
+  POSTGRES_DB_B: &postgres_db_b 'test_database_b'
+  POSTGRES_DB: *postgres_db_a
+  POSTGRES_USER_A: &postgres_user_a 'test_username'
+  POSTGRES_USER_B: &postgres_user_b 'test_username'
+  POSTGRES_USER: *postgres_user_a
+  POSTGRES_PASSWORD_A: &postgres_pass_a 'test_password'
+  POSTGRES_PASSWORD_B: &postgres_pass_b 'test_password'
+  POSTGRES_PASSWORD: *postgres_pass_a
 
 jobs:
   api-breakage:
@@ -42,35 +42,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - postgres-image-a: 'postgres:12'
-            postgres-image-b: 'postgres:13'
+          - postgres-image-a: 'postgres:13'
+            postgres-image-b: 'postgres:14'
             postgres-auth: 'trust'
-            swift-image: 'swift:5.10-jammy'
-          - postgres-image-a: 'postgres:14'
-            postgres-image-b: 'postgres:15'
-            postgres-auth: 'md5'
             swift-image: 'swift:6.0-noble'
-          - postgres-image-a: 'postgres:16'
-            postgres-image-b: 'postgres:17'
-            postgres-auth: 'scram-sha-256'
+          - postgres-image-a: 'postgres:15'
+            postgres-image-b: 'postgres:16'
+            postgres-auth: 'md5'
             swift-image: 'swift:6.1-noble'
+          - postgres-image-a: 'postgres:17'
+            postgres-image-b: 'postgres:18'
+            postgres-auth: 'scram-sha-256'
+            swift-image: 'swift:6.2-noble'
     container: ${{ matrix.swift-image }}
     runs-on: ubuntu-latest
     services:
-      psql-a:
+      *postgres_host_a:
         image: ${{ matrix.postgres-image-a }}
         env:
-          POSTGRES_USER: 'test_username'
-          POSTGRES_DB: 'test_database_a'
-          POSTGRES_PASSWORD: 'test_password'
+          POSTGRES_USER: *postgres_user_a
+          POSTGRES_DB: *postgres_db_a
+          POSTGRES_PASSWORD: *postgres_pass_a
           POSTGRES_HOST_AUTH_METHOD: ${{ matrix.postgres-auth }}
           POSTGRES_INITDB_ARGS: --auth-host=${{ matrix.postgres-auth }}
-      psql-b:
+      *postgres_host_b:
         image: ${{ matrix.postgres-image-b }}
         env:
-          POSTGRES_USER: 'test_username'
-          POSTGRES_DB: 'test_database_b'
-          POSTGRES_PASSWORD: 'test_password'
+          POSTGRES_USER: *postgres_user_b
+          POSTGRES_DB: *postgres_db_b
+          POSTGRES_PASSWORD: *postgres_pass_b
           POSTGRES_HOST_AUTH_METHOD: ${{ matrix.postgres-auth }}
           POSTGRES_INITDB_ARGS: --auth-host=${{ matrix.postgres-auth }}
     steps:
@@ -79,7 +79,7 @@ jobs:
       - name: Check out package
         uses: actions/checkout@v5
       - name: Run all tests
-        run: swift test --enable-code-coverage
+        run: swift test --enable-code-coverage --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable
       - name: Submit coverage report to Codecov.io
         uses: vapor/swift-codecov-action@v0.3
         with:
@@ -92,6 +92,8 @@ jobs:
       matrix:
         include:
           - macos-version: macos-15
+            xcode-version: latest-stable
+          - macos-version: macos-26
             xcode-version: latest-stable
     runs-on: ${{ matrix.macos-version }}
     env:
@@ -108,7 +110,7 @@ jobs:
         run: |
           brew upgrade || true
           export PATH="$(brew --prefix)/opt/postgresql@16/bin:$PATH" PGDATA=/tmp/vapor-postgres-test PGUSER="${POSTGRES_USER_A}"
-          brew install postgresql@17 && brew link --force postgresql@17
+          brew install postgresql@18 && brew link --force postgresql@18
           initdb --locale=C --auth-host "scram-sha-256" -U "${POSTGRES_USER_A}" --pwfile=<(echo "${POSTGRES_PASSWORD_A}")
           pg_ctl start --wait
           PGPASSWORD="${POSTGRES_PASSWORD_A}" createdb -w -O "${POSTGRES_USER_A}" "${POSTGRES_DB_A}"
@@ -119,4 +121,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Run all tests
-        run: swift test
+        run: swift test --enable-code-coverage --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable
+      - name: Submit coverage report to Codecov.io
+        uses: vapor/swift-codecov-action@v0.3
+        with:
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
+  musl:
+    runs-on: ubuntu-latest
+    container: swift:6.2-noble
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+      - name: Install SDK
+        run: swift sdk install https://download.swift.org/swift-6.2-release/static-sdk/swift-6.2-RELEASE/swift-6.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d2225840e592389ca517bbf71652f7003dbf45ac35d1e57d98b9250368769378
+      - name: Build
+        run: swift build --swift-sdk x86_64-swift-linux-musl

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
 
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("InternalImportsByDefault"),
+    //.enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("InferIsolatedConformances"),
     //.enableUpcomingFeature("NonisolatedNonsendingByDefault"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.52.2"),
-        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.14.0"),
+        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.14.1"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.21.0"),
     ],
     targets: [
@@ -41,9 +41,9 @@ let package = Package(
 
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
-    .enableUpcomingFeature("ConciseMagicFile"),
-    .enableUpcomingFeature("ForwardTrailingClosures"),
-    .enableUpcomingFeature("DisableOutwardActorInference"),
-    .enableExperimentalFeature("StrictConcurrency=complete"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    //.enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
 ] }

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 <a href="https://discord.gg/vapor"><img src="https://design.vapor.codes/images/discordchat.svg" alt="Team Chat"></a>
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
 <a href="https://github.com/vapor/fluent-postgres-driver/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/fluent-postgres-driver/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
-<a href="https://codecov.io/github/vapor/fluent-postgres-driver"><img src="https://img.shields.io/codecov/c/github/vapor/fluent-postgres-driver?style=plastic&logo=codecov&label=codecov"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift510up.svg" alt="Swift 5.10+"></a>
+<a href="https://codecov.io/github/vapor/fluent-postgres-driver"><img src="https://img.shields.io/codecov/c/github/vapor/fluent-postgres-driver?style=plastic&logo=codecov&label=codecov" alt="Code Coverage"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift60up.svg" alt="Swift 6.0+"></a>
 </p>
 
 <br>

--- a/Sources/FluentPostgresDriver/Docs.docc/theme-settings.json
+++ b/Sources/FluentPostgresDriver/Docs.docc/theme-settings.json
@@ -1,6 +1,6 @@
 {
   "theme": {
-    "aside": { "border-radius": "16px", "border-style": "double", "border-width": "3px" },
+    "aside": { "border-radius": "16px", "border-width": "3px", "border-style": "double" },
     "border-radius": "0",
     "button": { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
     "code":   { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
@@ -8,9 +8,9 @@
       "fluentpsqldriver": "#336791",
       "documentation-intro-fill": "radial-gradient(circle at top, var(--color-fluentpsqldriver) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-fluentpsqldriver)",
-      "documentation-intro-eyebrow": "white",
+      "hero-eyebrow": "white",
       "documentation-intro-figure": "white",
-      "documentation-intro-title": "white",
+      "hero-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }

--- a/Sources/FluentPostgresDriver/PostgresError+Database.swift
+++ b/Sources/FluentPostgresDriver/PostgresError+Database.swift
@@ -107,10 +107,5 @@ extension PSQLError {
     }
 }
 
-#if compiler(<6)
-extension PostgresError: DatabaseError {}
-extension PSQLError: DatabaseError {}
-#else
 extension PostgresError: @retroactive DatabaseError {}
 extension PSQLError: @retroactive DatabaseError {}
-#endif

--- a/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
@@ -118,8 +118,8 @@ struct FluentPostgresDriverTests {
             try await sql2.create(table: "foo").column("name", type: .text, .unique).run()
             try await sql2.insert(into: "foo").columns("name").values("bar").run()
             let error2 = await #expect(throws: (any Error).self) { try await sql2.insert(into: "foo").columns("name").values("bar").run() }
-            #expect((error2 as? any DatabaseError)?.isSyntaxError ?? false, "\(String(reflecting: error2))")
-            #expect(!((error2 as? any DatabaseError)?.isConstraintFailure ?? true), "\(String(reflecting: error2))")
+            #expect(!((error2 as? any DatabaseError)?.isSyntaxError ?? true), "\(String(reflecting: error2))")
+            #expect((error2 as? any DatabaseError)?.isConstraintFailure ?? false, "\(String(reflecting: error2))")
             #expect(!((error2 as? any DatabaseError)?.isConnectionClosed ?? true), "\(String(reflecting: error2))")
         }
 

--- a/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
@@ -322,11 +322,11 @@ extension DatabaseConfigurationFactory {
         decodingContext: PostgresDecodingContext<some PostgresJSONDecoder> = .default
     ) -> Self {
         let baseSubconfig = SQLPostgresConfiguration(
-            hostname: ProcessInfo.processInfo.environment["POSTGRES_HOSTNAME_\(subconfig)"] ?? "localhost",
-            port: ProcessInfo.processInfo.environment["POSTGRES_PORT_\(subconfig)"].flatMap(Int.init) ?? SQLPostgresConfiguration.ianaPortNumber,
-            username: ProcessInfo.processInfo.environment["POSTGRES_USER_\(subconfig)"] ?? "test_username",
-            password: ProcessInfo.processInfo.environment["POSTGRES_PASSWORD_\(subconfig)"] ?? "test_password",
-            database: ProcessInfo.processInfo.environment["POSTGRES_DB_\(subconfig)"] ?? "test_database",
+            hostname: env("POSTGRES_HOSTNAME_\(subconfig)") ?? env("POSTGRES_HOSTNAME_A") ?? env("POSTGRES_HOSTNAME") ?? "localhost",
+            port:    (env("POSTGRES_PORT_\(subconfig)")     ?? env("POSTGRES_PORT_A")     ?? env("POSTGRES_PORT")).flatMap(Int.init) ?? SQLPostgresConfiguration.ianaPortNumber,
+            username: env("POSTGRES_USER_\(subconfig)")     ?? env("POSTGRES_USER_A")     ?? env("POSTGRES_USER") ?? "test_username",
+            password: env("POSTGRES_PASSWORD_\(subconfig)") ?? env("POSTGRES_PASSWORD_A") ?? env("POSTGRES_PASSWORD") ?? "test_password",
+            database: env("POSTGRES_DB_\(subconfig)")       ?? env("POSTGRES_DB_A")       ?? env("POSTGRES_DB") ?? "test_database",
             tls: try! .prefer(.init(configuration: .makeClientConfiguration()))
         )
 
@@ -445,8 +445,12 @@ struct EnumAddMultipleCasesMigration: AsyncMigration {
     }
 }
 
+func env(_ e: String) -> String? {
+    ProcessInfo.processInfo.environment[e]
+}
+
 let isLoggingConfigured: Bool = {
-    LoggingSystem.bootstrap { QuickLogHandler(label: $0, level: ProcessInfo.processInfo.environment["LOG_LEVEL"].flatMap { .init(rawValue: $0) } ?? .info) }
+    LoggingSystem.bootstrap { QuickLogHandler(label: $0, level: env("LOG_LEVEL").flatMap { .init(rawValue: $0) } ?? .info) }
     return true
 }()
 

--- a/Tests/FluentPostgresDriverTests/FluentPostgresTransactionControlTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresTransactionControlTests.swift
@@ -1,92 +1,43 @@
-import FluentBenchmark
 import FluentKit
-import FluentPostgresDriver
-import Logging
-import PostgresKit
-import XCTest
+import Testing
 
-final class FluentPostgresTransactionControlTests: XCTestCase {
-    func testRollback() async throws {
-        do {
-            try await self.db.withConnection { db -> EventLoopFuture<Void> in
-                (db as! any TransactionControlDatabase).beginTransaction().flatMap { () -> EventLoopFuture<Void> in
-                    let todo1 = Todo(title: "Test")
-                    return todo1.save(on: db)
-                }.flatMap { () -> EventLoopFuture<Void> in
-                    let duplicate = Todo(title: "Test")
-                    return duplicate.create(on: db)
-                        .flatMap {
-                            (db as! any TransactionControlDatabase).commitTransaction()
-                        }.flatMapError { (e: Error) -> EventLoopFuture<Void> in
-                            return (db as! any TransactionControlDatabase).rollbackTransaction()
-                                .flatMap { db.eventLoop.makeFailedFuture(e) }
-                        }
+extension AllSuites {
+@Suite
+struct FluentPostgresTransactionControlTests {
+    init() { #expect(isLoggingConfigured) }
+
+    @Test
+    func rollback() async throws {
+        try await withDbs { _, db in try await db.withConnection { db in
+            try await CreateTodo().prepare(on: db)
+            do {
+                try await (db as! any TransactionControlDatabase).beginTransaction().get()
+                let error = await #expect(throws: (any Error).self) {
+                    try await [Todo(title: "Test"), Todo(title: "Test")].create(on: db)
+                    try await (db as! any TransactionControlDatabase).commitTransaction().get()
                 }
-            }.get()
-            XCTFail("Expected error but none was thrown")
-        } catch let error where String(reflecting: error).contains("sqlState: 23505") {
-            // ignore
-        } catch {
-            XCTFail("Expected SQL state 23505 but got \(String(reflecting: error))")
-        }
-
-        let count2 = try await Todo.query(on: self.db).count()
-        XCTAssertEqual(count2, 0)
-    }
-
-    var eventLoopGroup: any EventLoopGroup { MultiThreadedEventLoopGroup.singleton }
-    var threadPool: NIOThreadPool { NIOThreadPool.singleton }
-    var dbs: Databases!
-    var db: (any Database)!
-
-    override func setUp() async throws {
-        try await super.setUp()
-
-        XCTAssert(isLoggingConfigured)
-        self.dbs = Databases(threadPool: self.threadPool, on: self.eventLoopGroup)
-
-        self.dbs.use(.testPostgres(subconfig: "A"), as: .a)
-
-        self.db = self.dbs.database(.a, logger: Logger(label: "test.fluent.a"), on: self.eventLoopGroup.any())
-        _ = try await (self.db as! any PostgresDatabase).query("drop schema public cascade").get()
-        _ = try await (self.db as! any PostgresDatabase).query("create schema public").get()
-
-        try await CreateTodo().prepare(on: self.db)
-    }
-
-    override func tearDown() async throws {
-        try await CreateTodo().revert(on: self.db)
-        await self.dbs.shutdownAsync()
-        try await super.tearDown()
+                #expect(String(reflecting: error).contains("sqlState: 23505"), "\(String(reflecting: error))")
+                try await (db as! any TransactionControlDatabase).rollbackTransaction().get()
+                #expect(try await Todo.query(on: db).count() == 0)
+            } catch {
+                try? await CreateTodo().revert(on: db)
+                throw error
+            }
+            try await CreateTodo().revert(on: db)
+        } }
     }
 
     final class Todo: Model, @unchecked Sendable {
         static let schema = "todos"
-
-        @ID
-        var id: UUID?
-
-        @Field(key: "title")
-        var title: String
-
+        @ID var id
+        @Field(key: "title") var title: String
         init() {}
-        init(title: String) {
-            self.title = title
-            id = nil
-        }
+        init(title: String) { self.title = title }
     }
 
     struct CreateTodo: AsyncMigration {
-        func prepare(on database: any Database) async throws {
-            try await database.schema("todos")
-                .id()
-                .field("title", .string, .required)
-                .unique(on: "title")
-                .create()
-        }
-
-        func revert(on database: any Database) async throws {
-            try await database.schema("todos").delete()
-        }
+        func prepare(on database: any Database) async throws { try await database.schema(Todo.schema).id().field("title", .string, .required).unique(on: "title").create() }
+        func revert(on database: any Database) async throws { try await database.schema(Todo.schema).delete() }
     }
+}
 }

--- a/Tests/FluentPostgresDriverTests/FluentPostgresTransactionControlTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresTransactionControlTests.swift
@@ -6,6 +6,7 @@ extension AllSuites {
 struct FluentPostgresTransactionControlTests {
     init() { #expect(isLoggingConfigured) }
 
+    #if !compiler(<6.1) // #expect(throws:) doesn't return the Error until 6.1
     @Test
     func rollback() async throws {
         try await withDbs { _, db in try await db.withConnection { db in
@@ -26,7 +27,8 @@ struct FluentPostgresTransactionControlTests {
             try await CreateTodo().revert(on: db)
         } }
     }
-
+    #endif
+    
     final class Todo: Model, @unchecked Sendable {
         static let schema = "todos"
         @ID var id


### PR DESCRIPTION
**These changes are now available in [2.12.0](https://github.com/vapor/fluent-postgres-driver/releases/tag/2.12.0)**


Also update CI and convert the tests to SwiftTesting.